### PR TITLE
Add OauthToken interface

### DIFF
--- a/src/Contracts/OauthToken.php
+++ b/src/Contracts/OauthToken.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace OrigamiMp\OrigamiApiSdk\Contracts;
+
+use Carbon\Carbon;
+
+interface OauthToken
+{
+    public function getTokenType(): string;
+
+    public function getAccessToken(): string;
+
+    public function getRefreshToken(): string;
+
+    public function getExpiresAt(): Carbon;
+}

--- a/src/Dtos/Oauth/OauthTokenDto.php
+++ b/src/Dtos/Oauth/OauthTokenDto.php
@@ -3,11 +3,12 @@
 namespace OrigamiMp\OrigamiApiSdk\Dtos\Oauth;
 
 use Carbon\Carbon;
+use OrigamiMp\OrigamiApiSdk\Contracts\OauthToken;
 use OrigamiMp\OrigamiApiSdk\Dtos\ApiResponseDto;
 use OrigamiMp\OrigamiApiSdk\Exceptions\Dtos\ApiResponseDtoNotConstructableException;
 use OrigamiMp\OrigamiApiSdk\Exceptions\Dtos\Oauth\OauthTokenDtoNotConstructableException;
 
-class OauthTokenDto extends ApiResponseDto
+class OauthTokenDto extends ApiResponseDto implements OauthToken
 {
     /**
      * Most likely, will always contain 'Bearer'.
@@ -28,6 +29,26 @@ class OauthTokenDto extends ApiResponseDto
         parent::__construct($apiResponse);
 
         $this->validateAndFill();
+    }
+
+    public function getTokenType(): string
+    {
+        return $this->tokenType;
+    }
+
+    public function getAccessToken(): string
+    {
+        return $this->accessToken;
+    }
+
+    public function getRefreshToken(): string
+    {
+        return $this->refreshToken;
+    }
+
+    public function getExpiresAt(): Carbon
+    {
+        return $this->expiresAt;
     }
 
     protected function getDefaultDataStructureToProperties(): array

--- a/src/Repositories/Client/Data/OrigamiDataRestClient.php
+++ b/src/Repositories/Client/Data/OrigamiDataRestClient.php
@@ -2,7 +2,7 @@
 
 namespace OrigamiMp\OrigamiApiSdk\Repositories\Client\Data;
 
-use OrigamiMp\OrigamiApiSdk\Dtos\Oauth\OauthTokenDto;
+use OrigamiMp\OrigamiApiSdk\Contracts\OauthToken;
 use OrigamiMp\OrigamiApiSdk\Enums\Http\HttpRequestMethodEnum;
 use OrigamiMp\OrigamiApiSdk\ParamBags\RequestParamBag;
 use OrigamiMp\OrigamiApiSdk\Repositories\Client\OrigamiRestClient;
@@ -12,24 +12,24 @@ class OrigamiDataRestClient extends OrigamiRestClient
     /**
      * Oauth token that will be used for authenticating a certain User.
      */
-    private OauthTokenDto $oauthTokenDto;
+    private OauthToken $oauthToken;
 
     /**
      * Id of the UserGroup that should be used for authentication.
      */
     private ?int $userGroupId;
 
-    public function __construct(string $apiUri, OauthTokenDto $oauthTokenDto, ?int $userGroupId = null)
+    public function __construct(string $apiUri, OauthToken $oauthToken, ?int $userGroupId = null)
     {
         parent::__construct($apiUri);
 
-        $this->oauthTokenDto = $oauthTokenDto;
+        $this->oauthToken = $oauthToken;
         $this->userGroupId = $userGroupId;
     }
 
-    public function getOauthTokenDto(): OauthTokenDto
+    public function getoauthToken(): OauthToken
     {
-        return $this->oauthTokenDto;
+        return $this->oauthToken;
     }
 
     public function getUserGroupId(): ?int
@@ -60,7 +60,7 @@ class OrigamiDataRestClient extends OrigamiRestClient
     protected function getAuthentificationHeaders(): array
     {
         $headers = [
-            'Authorization' => "Bearer {$this->oauthTokenDto->accessToken}",
+            'Authorization' => "Bearer {$this->oauthToken->getAccessToken()}",
         ];
 
         if (! is_null($this->userGroupId)) {


### PR DESCRIPTION
Cette PR ajoute une interface représentant un OauthToken, qui sera utilisée pour l'initialisation du `OrigamiDataRestClient`.

Cela permet notamment au code qui utilise le SDK (la refonte de l'admin) de définir son propre modèle d'OauthToken, et de pouvoir le passer au DataRestClient du moment qu'il implémente cette interface.

C'est utile pour la refonte car par rapport au `OauthTokenDto` initialement présent dans le SDK, on utilise une version modifiée afin de permettre la communication avec le legacy. Cette interface permet donc d'utiliser cette version modifiée pour initialiser le DataRestClient.