### PR TITLE
Fix custom field DTO

### DIFF
--- a/src/Dtos/CustomField/CustomFieldTranslationDto.php
+++ b/src/Dtos/CustomField/CustomFieldTranslationDto.php
@@ -14,7 +14,7 @@ class CustomFieldTranslationDto extends ApiResponseDto
 
     public string $name;
 
-    public string $description;
+    public ?string $description;
 
     protected function getDefaultDataStructureToProperties(): array
     {
@@ -32,7 +32,7 @@ class CustomFieldTranslationDto extends ApiResponseDto
             'language_id' => ['required', 'integer'],
             'locale'      => ['required', 'string'],
             'name'        => ['present', 'string'],
-            'description' => ['present', 'string'],
+            'description' => ['present', 'nullable', 'string'],
         ];
     }
 


### PR DESCRIPTION
Fix the `CustomFieldDtoNotConstructableException` from `CustomFieldTranslationDto`:
`[CustomFieldDto] Could not assign data 'config.translations' to property`