### PR TITLE
Fix ParamBag missing trait-private properties in asEncodableArray

### DIFF
--- a/src/ParamBags/ParamBag.php
+++ b/src/ParamBags/ParamBag.php
@@ -3,6 +3,7 @@
 namespace OrigamiMp\OrigamiApiSdk\ParamBags;
 
 use Carbon\Carbon;
+use Closure;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Rules\RequiredIf;
@@ -11,7 +12,7 @@ abstract class ParamBag
 {
     protected function asEncodableArray(?array $propertiesList = null): array
     {
-        $allProperties = get_object_vars($this);
+        $allProperties = $this->getAllObjectVars();
 
         $properties = is_null($propertiesList) ? $allProperties : Arr::only($allProperties, $propertiesList);
         $propertiesAsSnakeCase = $this->propertyNamesToSnakeCase($properties);
@@ -27,6 +28,17 @@ abstract class ParamBag
         }
 
         return $encodableArray;
+    }
+
+    /**
+     * get_object_vars() only returns properties visible from the calling scope. Called directly here,
+     * it would miss private properties declared by traits used on subclasses (ex: HasIncludes::$include),
+     * since those are private to the subclass, not to this parent class. Binding the call to the object's
+     * own scope at runtime restores visibility of those properties.
+     */
+    private function getAllObjectVars(): array
+    {
+        return Closure::bind(fn () => get_object_vars($this), $this, $this)();
     }
 
     protected function castPropertyToEncodableType(mixed $propertyValue): int|string|array


### PR DESCRIPTION
## Summary

`/me` requests sent via the SDK were missing the `include` query param even when `GetCurrentUserRequestParamBag` was correctly configured with includes.

`ParamBag::asEncodableArray()` builds its property list via `get_object_vars($this)`. In PHP, this call only returns properties visible from the *lexical scope of the method that calls it* — here, `ParamBag` itself. Properties added via a trait (e.g. `HasIncludes::$include`) are declared `private`, but that privacy is scoped to the class using the trait (e.g. `GetCurrentUserRequestParamBag`), not to the parent `ParamBag` class. As a result, `get_object_vars($this)` silently dropped them, while properties like headers (built through a separate code path) were unaffected.

This fixes it by binding the `get_object_vars()` call to the object's own runtime scope via `Closure::bind`, so private trait properties declared on subclasses are picked up correctly.

## Test plan

- Manually verified `GetCurrentUserRequestParamBag::asGuzzleParams()` now includes `include` under `query` params, alongside `headers`, when includes are set.